### PR TITLE
Added tmpdir option, for improved backwards compatibility

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
 /node_modules/
 npm-debug.log
 /test/build
+/tmp

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 1.1.0
+
+Added `options.tmpdir`. Primarily useful if you depend on a Broccoli plugin that still assumes temporary build files to be placed in a `tmp` directory next to the Brocfile.
+
 ## 1.0.0
 
 A complete rewrite with inspiration and code from [broccoli](https://www.npmjs.com/package/broccoli)'s own CLI module.
@@ -6,7 +10,7 @@ Broccoli ^1.0.0 is now used, and tests load Grunt ^1.0.0.
 
 #### API changes
 
-Please note that apart from `dest`, all options now live in the `options` object. This is to align more closely with Grunt convention, and enables you to specify global options that can be locally overriden. Just like with any other Grunt plugin!
+Please note that apart from `dest`, all options now live in the `options` object. This is to align more closely with Grunt convention, and enables you to specify global options that can be locally overridden. Just like with any other Grunt plugin!
 
 ```js
 // Old config

--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -19,7 +19,8 @@ module.exports = function(grunt) {
       brocfile: {
         dest: 'test/build/brocfile',
         options: {
-          config: './test/fixtures/Brocfile.js'
+          config: './test/fixtures/Brocfile.js',
+          tmpdir: 'tmp'
         }
       },
       function: {

--- a/README.md
+++ b/README.md
@@ -54,7 +54,12 @@ module.exports = function(grunt) {
           // every rebuild
           incrementalOverwrite: true,
           // Which port to use with the 'serve' task
-          port: 4200
+          port: 4200,
+          // This option dictates where temporary files are placed while
+          // Broccoli executes a build. Before Broccoli 1.0.0, they were placed
+          // in a directory called `tmp` next to the Brocfile. After 1.0.0,
+          // they're normally placed in the OS's global tmp directory
+          tmpdir: undefined
         }
       },
       prod: {

--- a/tasks/broccoli.js
+++ b/tasks/broccoli.js
@@ -37,7 +37,8 @@ module.exports = function(grunt) {
       env: ['development', 'production', Joi.object()],
       host: Joi.string().hostname(),
       incrementalOverwrite: Joi.boolean(),
-      port: Joi.number()
+      port: Joi.number(),
+      tmpdir: Joi.string().optional()
     });
 
     Joi.attempt(
@@ -62,6 +63,11 @@ module.exports = function(grunt) {
       });
     }
 
+    if (options.tmpdir) {
+      options.tmpdir = path.resolve(process.cwd(), options.tmpdir);
+      mkdirp.sync(options.tmpdir);
+    }
+
     var originalCwd = process.cwd();
     var dest = path.resolve(process.cwd(), this.data.dest);
     var done = this.async();
@@ -76,7 +82,7 @@ module.exports = function(grunt) {
       outputNode = options.config();
     }
 
-    var builder = new broccoli.Builder(outputNode);
+    var builder = new broccoli.Builder(outputNode, { tmpdir: options.tmpdir });
 
     if (command === 'build') {
       builder


### PR DESCRIPTION
Fixes #4. Helpful when a plugin for some reason assumes that the temporary build directory should be placed next to Brocfile.